### PR TITLE
moved python editable installs to upper folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN chmod +x /usr/src/{{project_name}}/tasks.py \
     && chmod +x /usr/src/{{project_name}}/entrypoint.sh
 
 # app-specific requirements
-RUN pip install --upgrade --no-cache-dir -r requirements.txt
+RUN pip install --upgrade --no-cache-dir --src /usr/src -r requirements.txt
 RUN pip install --upgrade -e .
 
 ENTRYPOINT ["/usr/src/{{project_name}}/entrypoint.sh"]


### PR DESCRIPTION
This enables the mounting of the src folder for development, otherwise the /usr/src/my_geonode/src folder (created by pip) would get wiped out.